### PR TITLE
Check for bluemix before trying to source completion

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -33,12 +33,20 @@ set-environment -g "SSH_AUTH_SOCK" "$HOME/.ssh/ssh_auth_sock"
 
 # List of plugins
 set -g @plugin 'tmux-plugins/tpm'
+
 set -g @plugin 'tmux-plugins/tmux-sensible'
+
 set -g @plugin 'tmux-plugins/tmux-open'
+
 set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @shell_mode 'vi'
+
 set -g @plugin 'tmux-plugins/tmux-copycat'
+
 set -g @plugin 'tmux-plugins/tmux-fpp'
+
 set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
+
 set -g @plugin 'tmux-plugins/tmux-pain-control'
 
 # My theme

--- a/zsh/startup/bluemix.zsh
+++ b/zsh/startup/bluemix.zsh
@@ -1,0 +1,8 @@
+# The IBM BlueMix CLI
+# https://console.ng.bluemix.net/docs/cli/reference/bluemix_cli/index.html
+
+# This is where HomeBrew installs it on the Mac.
+# I'm not sure if this is the same on Linux.
+if [ -r /usr/local/Bluemix/bx/zsh_autocomplete ]; then
+  source /usr/local/Bluemix/bx/zsh_autocomplete
+fi

--- a/zshrc
+++ b/zshrc
@@ -11,6 +11,3 @@ unset config_file
 typeset -xU fpath path manpath
 
 test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"
-
-### Added by the Bluemix CLI
-source /usr/local/Bluemix/bx/zsh_autocomplete


### PR DESCRIPTION
This handles the bluemix completion without breaking if bluemix isn't installed.